### PR TITLE
필터링 기능, 상세페이지, 로딩페이지, 라우트

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,14 @@
 import { Provider } from "react-redux";
 import { store } from "./store/store";
-import IssuesPage from "./issuesList";
+import { RouterProvider } from "react-router-dom";
+import router from "./route/route";
 
 function App() {
   return (
     <Provider store={store}>
-      <div>
-        <h1>GitHub IssuesList</h1>
-      </div>
-      <IssuesPage />
+      <h1>GitHub IssuesList</h1>
+
+      <RouterProvider router={router} />
     </Provider>
   );
 }

--- a/src/issuesList/components/filter/issuesFilter.js
+++ b/src/issuesList/components/filter/issuesFilter.js
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { asyncIssues, setIssues } from "../../../reducer/issues";
+
+const IssuesFilter = () => {
+  const dispatch = useDispatch();
+
+  const { issues } = useSelector((state) => state.issues);
+
+  useEffect(() => {
+    dispatch(asyncIssues());
+  }, [dispatch]);
+
+  const onIssuesFilter = (e) => {
+    const filterValue = e.target.value;
+
+    // create_at
+    const createAtFilterIssuesArr = [...issues].reverse();
+
+    //updated_at
+    const updatedAtArr = issues.map((el) =>
+      el.updated_at.replace(/[\-\:TZ]/g, "")
+    );
+    updatedAtArr.sort((a, b) => b - a);
+
+    const updatedAtFilterIssuesArr = [];
+    for (let i = 0; i < updatedAtArr.length; i++) {
+      for (let j = 0; j < issues.length; j++) {
+        if (updatedAtArr[i] === issues[j].updated_at.replace(/[\-\:TZ]/g, "")) {
+          updatedAtFilterIssuesArr.push(issues[j]);
+        }
+      }
+    }
+
+    //comments
+    const commentArr = issues.map((el) => el.comments);
+    commentArr.sort((a, b) => b - a);
+    const commentFilterIssuesArr = [];
+    for (let i = 0; i < commentArr.length; i++) {
+      for (let j = 0; j < issues.length; j++) {
+        if (commentArr[i] === issues[j].comments) {
+          commentFilterIssuesArr.push(issues[j]);
+        }
+      }
+    }
+
+    if (filterValue === "생성") {
+      dispatch(setIssues(createAtFilterIssuesArr));
+    } else if (filterValue === "업데이트") {
+      dispatch(setIssues(updatedAtFilterIssuesArr));
+    } else if (filterValue === "댓글") {
+      dispatch(setIssues(commentFilterIssuesArr));
+    }
+  };
+
+  return (
+    <div>
+      <select onChange={onIssuesFilter}>
+        <option>-- 게시글 정렬 --</option>
+        <option>생성</option>
+        <option>업데이트</option>
+        <option>댓글</option>
+      </select>
+    </div>
+  );
+};
+export default IssuesFilter;

--- a/src/issuesList/components/oneIssuesList.js
+++ b/src/issuesList/components/oneIssuesList.js
@@ -1,13 +1,23 @@
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
 
 const OneIssuesList = ({ issues }) => {
+  const navigate = useNavigate();
   const updatedAt = issues.updated_at.replace("T", "-").replace("Z", "");
   const createAt = issues.created_at.replace("T", "-").replace("Z", "");
 
+  const onOpenDetailPage = () => {
+    navigate("/detailPage", {
+      state: {
+        issuesId: issues.id,
+      },
+    });
+  };
+
   return (
     <IssuesListPage>
-      <IssuesListBox>
+      <IssuesListBox onClick={onOpenDetailPage}>
         <IssuesTitle>
           {updatedAt}
           <p>{issues.title}</p>
@@ -33,6 +43,9 @@ const IssuesListBox = styled.div`
   width: 80%;
   height: 120px;
   margin: 20px;
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 const IssuesTitle = styled.div`

--- a/src/issuesList/detailPage/index.js
+++ b/src/issuesList/detailPage/index.js
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
+import { asyncIssues } from "../../reducer/issues";
+
+const DetailPage = () => {
+  const dispatch = useDispatch();
+  const { issues } = useSelector((state) => state.issues);
+  useEffect(() => {
+    dispatch(asyncIssues());
+  }, [dispatch]);
+
+  const location = useLocation();
+
+  const issuesId = location.state.issuesId;
+
+  const detailIssues =
+    issues !== null &&
+    issues.find((el) => {
+      return el.id === issuesId;
+    });
+
+  console.log(detailIssues);
+
+  return (
+    <div>
+      <p>{detailIssues.updated_at.replace("T", "-").replace("Z", "")}</p>
+      <h1>{detailIssues.title}</h1>
+      <p>{detailIssues.body}</p>
+      <a href={detailIssues.html_url}>링크</a>
+    </div>
+  );
+};
+export default DetailPage;

--- a/src/issuesList/index.js
+++ b/src/issuesList/index.js
@@ -4,13 +4,16 @@ import { useEffect } from "react";
 import OneIssuesList from "./components/oneIssuesList";
 import PageIssues from "./components/pagination";
 import ChangeShowNum from "./components/filter/changeShowNum";
+import IssuesFilter from "./components/filter/issuesFilter";
+import LoadingPage from "./lodingPage";
 
 const IssuesPage = () => {
   const dispatch = useDispatch();
-  const { issues } = useSelector((state) => state.issues);
-  const { currentPage, showPageNum } = useSelector((state) => state.issues);
+  const { currentPage, showPageNum, issues, status } = useSelector(
+    (state) => state.issues
+  );
 
-  console.log(currentPage);
+  console.log(status);
 
   // 이거 써야 issues값 사용 가능
   useEffect(() => {
@@ -23,7 +26,9 @@ const IssuesPage = () => {
 
   return (
     <div>
+      {status === "Loading" && <LoadingPage />}
       <ChangeShowNum />
+      <IssuesFilter />
       {issues !== null &&
         pageIssues.map((issues) => (
           <OneIssuesList key={issues.id} issues={issues} />

--- a/src/issuesList/lodingPage/index.js
+++ b/src/issuesList/lodingPage/index.js
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+const LoadingPage = () => {
+  return <LoadingDiv>로딩 중</LoadingDiv>;
+};
+export default LoadingPage;
+
+const LoadingDiv = styled.h1`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/reducer/issues.js
+++ b/src/reducer/issues.js
@@ -38,7 +38,7 @@ export const issuesSlice = createSlice({
   name: "issues",
   initialState,
   reducers: {
-    getIssues: (state, action) => {
+    setIssues: (state, action) => {
       state.issues = action.payload;
     },
     setCurrentPage: (state, action) => {
@@ -61,6 +61,7 @@ export const issuesSlice = createSlice({
       state.status = "Loading";
     });
     builder.addCase(asyncIssues.fulfilled, (state, action) => {
+      state.status = "success";
       state.issues = action.payload;
     });
     builder.addCase(asyncIssues.rejected, (state, action) => {
@@ -70,7 +71,7 @@ export const issuesSlice = createSlice({
 });
 
 export const {
-  getIssues,
+  setIssues,
   setCurrentPage,
   setStartPage,
   setEndPage,

--- a/src/route/route.js
+++ b/src/route/route.js
@@ -1,0 +1,16 @@
+import { createBrowserRouter } from "react-router-dom";
+import IssuesPage from "../issuesList";
+import DetailPage from "../issuesList/detailPage";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <IssuesPage />,
+  },
+  {
+    path: "/detailPage",
+    element: <DetailPage />,
+  },
+]);
+
+export default router;


### PR DESCRIPTION
1. 라우트
상세 페이지 구현을 위해 react-router-dom을 사용했습니다

2. 상세페이지
이슈 목록을 클릭 시 해당 이슈의 상세페이지로 이동됩니다

3. 로딩 페이지
이슈 목록이 화면에 랜더링되는 동안 로딩 중이 화면에 랜더됩니다

4. 필터링 기능
이슈 목록을 생성순/업데이트순/댓글순으로 정렬해서 볼 수 있는 기능을 추가했습니다